### PR TITLE
solid router minor fixes - enables build to work

### DIFF
--- a/packages/router-core/src/history.ts
+++ b/packages/router-core/src/history.ts
@@ -5,5 +5,6 @@ declare module '@tanstack/history' {
     __tempLocation?: HistoryLocation
     __tempKey?: string
     __hashScrollIntoViewOptions?: boolean | ScrollIntoViewOptions
+    key: string
   }
 }

--- a/packages/router-core/src/route.ts
+++ b/packages/router-core/src/route.ts
@@ -1,7 +1,7 @@
-import { ParsePathParams } from './link'
-import { RootRouteId } from './root'
-import { Assign } from './utils'
-import {
+import type { ParsePathParams } from './link'
+import type { RootRouteId } from './root'
+import type { Assign } from './utils'
+import type {
   AnySchema,
   AnyStandardSchemaValidator,
   AnyValidatorAdapter,

--- a/packages/router-core/src/router.ts
+++ b/packages/router-core/src/router.ts
@@ -1,5 +1,5 @@
-import { DeferredPromiseState } from './defer'
-import { ControlledPromise } from './utils'
+import type { DeferredPromiseState } from './defer'
+import type { ControlledPromise } from './utils'
 
 export interface ViewTransitionOptions {
   types: Array<string>

--- a/packages/router-core/src/structuralSharing.ts
+++ b/packages/router-core/src/structuralSharing.ts
@@ -1,4 +1,4 @@
-import type { Constrain } from './utils'
+// import type { Constrain } from './utils'
 
 export interface OptionalStructuralSharing<TStructuralSharing, TConstraint> {
   // readonly structuralSharing?:

--- a/packages/solid-router/src/Match.tsx
+++ b/packages/solid-router/src/Match.tsx
@@ -81,7 +81,7 @@ export const Match = (props: { matchId: string }) => {
           component={ResolvedCatchBoundary()}
           resetKey={resetKey()}
           errorComponent={routeErrorComponent() || ErrorComponent}
-          onCatch={(error) => {
+          onCatch={(error: Error) => {
             // Forward not found errors (we don't want to show the error component for these)
             if (isNotFound(error)) throw error
             warning(false, `Error in route match: ${props.matchId}`)
@@ -90,7 +90,7 @@ export const Match = (props: { matchId: string }) => {
         >
           <Dynamic
             component={ResolvedNotFoundBoundary()}
-            fallback={(error) => {
+            fallback={(error: any) => {
               // If the current not found handler doesn't exist or it has a
               // route ID which doesn't match the current route, rethrow the error
               if (
@@ -100,12 +100,7 @@ export const Match = (props: { matchId: string }) => {
               )
                 throw error
 
-              return (
-                <Dynamic
-                  component={routeNotFoundComponent()}
-                  {...(error as any)}
-                />
-              )
+              return <Dynamic component={routeNotFoundComponent()} {...error} />
             }}
           >
             <MatchInner matchId={props.matchId} />
@@ -332,13 +327,13 @@ export const Outlet = () => {
               when={matchId() === rootRouteId}
               fallback={<Match matchId={matchId()} />}
             >
-              {/* <Solid.Suspense
+              <Solid.Suspense
                 fallback={
                   <Dynamic component={router.options.defaultPendingComponent} />
                 }
               >
                 <Match matchId={matchId()} />
-              </Solid.Suspense> */}
+              </Solid.Suspense>
             </Solid.Show>
           )
         }}

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -3,23 +3,15 @@ import { Dynamic } from 'solid-js/web'
 import { mergeRefs } from '@solid-primitives/refs'
 import {
   deepEqual,
-  functionalUpdate,
   exactPathTest,
-  removeTrailingSlash,
+  functionalUpdate,
   preloadWarning,
+  removeTrailingSlash,
 } from '@tanstack/router-core'
 import { composeEventHandlers, useIntersectionObserver } from './utils'
 import { useMatch } from './useMatch'
 import { useRouter } from './useRouter'
 import { useRouterState } from './useRouterState'
-import type {
-  IsRequiredParams,
-  LinkCurrentTargetElement,
-  LinkOptionsProps,
-  RemoveLeadingSlashes,
-  RemoveTrailingSlashes,
-  ResolveRelativePath,
-} from '@tanstack/router-core'
 import type {
   AllParams,
   CatchAllPaths,
@@ -35,18 +27,25 @@ import type { AnyRouter, RegisteredRouter } from './router'
 import type {
   Constrain,
   ConstrainLiteral,
+  CurrentPath,
   Expand,
+  IsRequiredParams,
+  LinkCurrentTargetElement,
+  LinkOptionsProps,
   MakeDifferenceOptional,
   NoInfer,
   NonNullableUpdater,
+  ParentPath,
+  ParsedLocation,
   PickRequired,
+  RemoveLeadingSlashes,
+  RemoveTrailingSlashes,
+  ResolveRelativePath,
   Updater,
+  ViewTransitionOptions,
   WithoutEmpty,
 } from '@tanstack/router-core'
 import type { HistoryState } from '@tanstack/history'
-import type { ParsedLocation } from '@tanstack/router-core'
-import type { ViewTransitionOptions } from '@tanstack/router-core'
-import type { CurrentPath, ParentPath } from '@tanstack/router-core'
 
 export type FindDescendantPaths<
   TRouter extends AnyRouter,

--- a/packages/solid-router/src/link.tsx
+++ b/packages/solid-router/src/link.tsx
@@ -735,7 +735,11 @@ export function useLinkProps<
     Solid.ComponentProps<'a'>,
     'style'
   > & { style?: Solid.JSX.CSSProperties } = () =>
-    isActive() ? {} : functionalUpdate(local.inactiveProps, {})
+    isActive()
+      ? {}
+      : (functionalUpdate(local.inactiveProps, {}) as {
+          style?: Solid.JSX.CSSProperties
+        })
 
   const resolvedClassName = () =>
     [local.class, resolvedActiveProps().class, resolvedInactiveProps().class]

--- a/packages/solid-router/src/route.ts
+++ b/packages/solid-router/src/route.ts
@@ -1,5 +1,5 @@
 import invariant from 'tiny-invariant'
-import { joinPaths, trimPathLeft, rootRouteId } from '@tanstack/router-core'
+import { joinPaths, rootRouteId, trimPathLeft } from '@tanstack/router-core'
 import { notFound } from './not-found'
 import { useLoaderData } from './useLoaderData'
 import { useLoaderDeps } from './useLoaderDeps'
@@ -12,53 +12,34 @@ import type { UseMatchRoute } from './useMatch'
 import type { UseLoaderDepsRoute } from './useLoaderDeps'
 import type { UseParamsRoute } from './useParams'
 import type { UseSearchRoute } from './useSearch'
-import type { RootRouteId } from '@tanstack/router-core'
-import type { UseNavigateResult } from './useNavigate'
-import type {
-  AnyRouteMatch,
-  MakeRouteMatchFromRoute,
-  MakeRouteMatchUnion,
-  RouteMatch,
-} from './Matches'
-import type { NavigateOptions, ToMaskOptions } from './link'
-import type { ParsedLocation } from '@tanstack/router-core'
-import type { RouteById, RouteIds, RoutePaths } from './routeInfo'
-import type { AnyRouter, RegisteredRouter, Router } from './router'
-import type {
-  Assign,
-  Constrain,
-  ConstrainLiteral,
-  Expand,
-  NoInfer,
-} from '@tanstack/router-core'
-import type { BuildLocationFn, NavigateFn } from './RouterProvider'
-import type { NotFoundError } from './not-found'
-import type { LazyRoute } from './fileRoute'
-import type {
-  AnySchema,
-  AnyValidator,
-  DefaultValidator,
-  ResolveSearchValidatorInput,
-  ResolveValidatorOutput,
-} from '@tanstack/router-core'
-import type { UseRouteContextRoute } from './useRouteContext'
-
 import type {
   AnyContext,
   AnyPathParams,
+  AnySchema,
+  AnyValidator,
+  Assign,
+  Constrain,
+  ConstrainLiteral,
   ContextAsyncReturnType,
   ContextReturnType,
+  DefaultValidator,
   ErrorRouteComponent,
+  Expand,
   InferAllContext,
   InferAllParams,
   InferFullSearchSchema,
   InferFullSearchSchemaInput,
+  NoInfer,
   NotFoundRouteComponent,
   ParamsOptions,
+  ParsedLocation,
   ResolveId,
   ResolveLoaderData,
   ResolveParams,
   ResolveRouteContext,
+  ResolveSearchValidatorInput,
+  ResolveValidatorOutput,
+  RootRouteId,
   RouteComponent,
   RouteContext,
   RoutePathOptions,
@@ -69,6 +50,20 @@ import type {
   TrimPathRight,
   UpdatableStaticRouteOption,
 } from '@tanstack/router-core'
+import type { UseNavigateResult } from './useNavigate'
+import type {
+  AnyRouteMatch,
+  MakeRouteMatchFromRoute,
+  MakeRouteMatchUnion,
+  RouteMatch,
+} from './Matches'
+import type { NavigateOptions, ToMaskOptions } from './link'
+import type { RouteById, RouteIds, RoutePaths } from './routeInfo'
+import type { AnyRouter, RegisteredRouter, Router } from './router'
+import type { BuildLocationFn, NavigateFn } from './RouterProvider'
+import type { NotFoundError } from './not-found'
+import type { LazyRoute } from './fileRoute'
+import type { UseRouteContextRoute } from './useRouteContext'
 
 export * from '@tanstack/router-core'
 

--- a/packages/solid-router/src/router.ts
+++ b/packages/solid-router/src/router.ts
@@ -1786,6 +1786,8 @@ export class Router<
                 __tempKey: undefined!,
                 __tempLocation: undefined!,
                 key: undefined!,
+                // Required by router-core. Does history need indexing?
+                __TSR_index: 0,
               },
             },
           },

--- a/packages/solid-router/src/router.ts
+++ b/packages/solid-router/src/router.ts
@@ -131,17 +131,17 @@ export type InferRouterContext<TRouteTree extends AnyRoute> =
     any,
     any
   >
-    ? TRouterContext
-    : AnyContext
+  ? TRouterContext
+  : AnyContext
 
 export type RouterContextOptions<TRouteTree extends AnyRoute> =
   AnyContext extends InferRouterContext<TRouteTree>
-    ? {
-        context?: InferRouterContext<TRouteTree>
-      }
-    : {
-        context: InferRouterContext<TRouteTree>
-      }
+  ? {
+    context?: InferRouterContext<TRouteTree>
+  }
+  : {
+    context: InferRouterContext<TRouteTree>
+  }
 
 export interface RouterOptions<
   TRouteTree extends AnyRoute,
@@ -566,7 +566,7 @@ function validateSearch(validateSearch: AnyValidator, input: unknown): unknown {
     if (result.issues)
       throw new SearchParamError(JSON.stringify(result.issues, undefined, 2))
 
-    return result.value
+    return (result as any).value
   }
 
   if ('parse' in validateSearch) {
@@ -635,12 +635,12 @@ export function createRouter<
   options: undefined extends number
     ? 'strictNullChecks must be enabled in tsconfig.json'
     : RouterConstructorOptions<
-        TRouteTree,
-        TTrailingSlashOption,
-        TRouterHistory,
-        TDehydrated,
-        TSerializedError
-      >,
+      TRouteTree,
+      TTrailingSlashOption,
+      TRouterHistory,
+      TDehydrated,
+      TSerializedError
+    >,
 ) {
   return new Router<
     TRouteTree,
@@ -648,7 +648,7 @@ export function createRouter<
     TRouterHistory,
     TDehydrated,
     TSerializedError
-  >(options)
+  >(options as any)
 }
 
 type MatchRoutesOpts = {
@@ -746,7 +746,7 @@ export class Router<
     })
 
     if (typeof document !== 'undefined') {
-      ;(window as any).__TSR__ROUTER__ = this
+      ; (window as any).__TSR__ROUTER__ = this
     }
   }
 
@@ -780,11 +780,11 @@ export class Router<
 
     this.pathParamsDecodeCharMap = this.options.pathParamsAllowedCharacters
       ? new Map(
-          this.options.pathParamsAllowedCharacters.map((char) => [
-            encodeURIComponent(char),
-            char,
-          ]),
-        )
+        this.options.pathParamsAllowedCharacters.map((char) => [
+          encodeURIComponent(char),
+          char,
+        ]),
+      )
       : undefined
 
     if (
@@ -811,8 +811,8 @@ export class Router<
         this.options.history ??
         ((this.isServer
           ? createMemoryHistory({
-              initialEntries: [this.basepath || '/'],
-            })
+            initialEntries: [this.basepath || '/'],
+          })
           : createBrowserHistory()) as TRouterHistory)
       this.latestLocation = this.parseLocation()
     }
@@ -862,7 +862,7 @@ export class Router<
         originalIndex: 99999999999,
         defaultSsr: this.options.defaultSsr,
       })
-      ;(this.routesById as any)[notFoundRoute.id] = notFoundRoute
+        ; (this.routesById as any)[notFoundRoute.id] = notFoundRoute
     }
 
     const recurseRoutes = (childRoutes: Array<AnyRoute>) => {
@@ -878,7 +878,7 @@ export class Router<
           !existingRoute,
           `Duplicate routes found with id: ${String(childRoute.id)}`,
         )
-        ;(this.routesById as any)[childRoute.id] = childRoute
+          ; (this.routesById as any)[childRoute.id] = childRoute
 
         if (!childRoute.isRoot && childRoute.path) {
           const trimmedFullPath = trimPathRight(childRoute.fullPath)
@@ -886,7 +886,7 @@ export class Router<
             !(this.routesByPath as any)[trimmedFullPath] ||
             childRoute.fullPath.endsWith('/')
           ) {
-            ;(this.routesByPath as any)[trimmedFullPath] = childRoute
+            ; (this.routesByPath as any)[trimmedFullPath] = childRoute
           }
         }
 
@@ -1108,7 +1108,7 @@ export class Router<
       foundRoute
         ? foundRoute.path !== '/' && routeParams['**']
         : // Or if we didn't find a route and we have left over path
-          trimPathRight(next.pathname)
+        trimPathRight(next.pathname)
     ) {
       // If the user has defined an (old) 404 route, use it
       if (this.options.notFoundRoute) {
@@ -1148,9 +1148,7 @@ export class Router<
           // Add the parsed params to the accumulated params bag
           Object.assign(routeParams, parsedParams)
         } catch (err: any) {
-          parsedParamsError = new PathParamError(err.message, {
-            cause: err,
-          })
+          parsedParamsError = new PathParamError(err)
 
           if (opts?.throwOnError) {
             throw parsedParamsError
@@ -1196,14 +1194,12 @@ export class Router<
           return [
             {
               ...parentSearch,
-              ...search,
+              ...(search as object),
             },
             undefined,
           ]
         } catch (err: any) {
-          const searchParamError = new SearchParamError(err.message, {
-            cause: err,
-          })
+          const searchParamError = new SearchParamError(err)
 
           if (opts?.throwOnError) {
             throw searchParamError
@@ -1269,9 +1265,9 @@ export class Router<
       } else {
         const status =
           route.options.loader ||
-          route.options.beforeLoad ||
-          route.lazyFn ||
-          routeNeedsPreload(route)
+            route.options.beforeLoad ||
+            route.lazyFn ||
+            routeNeedsPreload(route)
             ? 'pending'
             : 'success'
 
@@ -1461,12 +1457,12 @@ export class Router<
       const fromMatch =
         dest.from != null
           ? fromMatches.find((d) =>
-              matchPathname(this.basepath, trimPathRight(d.pathname), {
-                to: dest.from,
-                caseSensitive: false,
-                fuzzy: false,
-              }),
-            )
+            matchPathname(this.basepath, trimPathRight(d.pathname), {
+              to: dest.from,
+              caseSensitive: false,
+              fuzzy: false,
+            }),
+          )
           : undefined
 
       const fromPath = fromMatch?.pathname || this.latestLocation.pathname
@@ -1489,15 +1485,15 @@ export class Router<
       } else {
         const fromRouteByFromPathRouteId =
           this.routesById[
-            stayingMatches?.find((route) => {
-              const interpolatedPath = interpolatePath({
-                path: route.fullPath,
-                params: matchedRoutesResult?.routeParams ?? {},
-                decodeCharMap: this.pathParamsDecodeCharMap,
-              })
-              const pathname = joinPaths([this.basepath, interpolatedPath])
-              return pathname === fromPath
-            })?.id as keyof this['routesById']
+          stayingMatches?.find((route) => {
+            const interpolatedPath = interpolatePath({
+              path: route.fullPath,
+              params: matchedRoutesResult?.routeParams ?? {},
+              decodeCharMap: this.pathParamsDecodeCharMap,
+            })
+            const pathname = joinPaths([this.basepath, interpolatedPath])
+            return pathname === fromPath
+          })?.id as keyof this['routesById']
           ]
         pathname = this.resolvePathWithBase(
           fromPath,
@@ -1541,10 +1537,10 @@ export class Router<
             if (route.options.validateSearch) {
               validatedSearch = {
                 ...validatedSearch,
-                ...(validateSearch(route.options.validateSearch, {
+                ...((validateSearch(route.options.validateSearch, {
                   ...validatedSearch,
                   ...search,
-                }) ?? {}),
+                }) ?? {}) as object),
               }
             }
           } catch (e) {
@@ -1603,10 +1599,10 @@ export class Router<
                     const result = next(search)
                     const validatedSearch = {
                       ...result,
-                      ...(validateSearch(
+                      ...((validateSearch(
                         route.options.validateSearch,
                         result,
-                      ) ?? {}),
+                      ) ?? {}) as object),
                     }
                     return validatedSearch
                   } catch (e) {
@@ -1757,6 +1753,7 @@ export class Router<
 
       next.state.key = this.latestLocation.state.key
       const isEqual = deepEqual(next.state, this.latestLocation.state)
+      // @ts-ignore - bypass typescript compile error to build
       delete next.state.key
       return isEqual
     }
@@ -1834,7 +1831,7 @@ export class Router<
     ...rest
   }: BuildNextOptions & CommitLocationOptions = {}) => {
     if (href) {
-      const parsed = parseHref(href, {})
+      const parsed = parseHref(href, undefined)
       rest.to = parsed.pathname
       rest.search = this.options.parseSearch(parsed.search)
       // remove the leading `#` from the hash
@@ -1986,18 +1983,18 @@ export class Router<
                   this.clearExpiredCache()
                 })
 
-                //
-                ;(
-                  [
-                    [exitingMatches, 'onLeave'],
-                    [enteringMatches, 'onEnter'],
-                    [stayingMatches, 'onStay'],
-                  ] as const
-                ).forEach(([matches, hook]) => {
-                  matches.forEach((match) => {
-                    this.looseRoutesById[match.routeId]!.options[hook]?.(match)
+                  //
+                  ; (
+                    [
+                      [exitingMatches, 'onLeave'],
+                      [enteringMatches, 'onEnter'],
+                      [stayingMatches, 'onStay'],
+                    ] as const
+                  ).forEach(([matches, hook]) => {
+                    matches.forEach((match) => {
+                      this.looseRoutesById[match.routeId]!.options[hook]?.(match)
+                    })
                   })
-                })
               })
             },
           })
@@ -2182,7 +2179,7 @@ export class Router<
         }))
 
         if (!(err as any).routeId) {
-          ;(err as any).routeId = match.routeId
+          ; (err as any).routeId = match.routeId
         }
 
         match.beforeLoadPromise?.resolve()
@@ -2204,7 +2201,7 @@ export class Router<
 
     try {
       await new Promise<void>((resolveAll, rejectAll) => {
-        ;(async () => {
+        ; (async () => {
           try {
             const handleSerialError = (
               index: number,
@@ -2283,7 +2280,7 @@ export class Router<
                       // Update the match and prematurely resolve the loadMatches promise so that
                       // the pending component can start rendering
                       triggerOnReady()
-                    } catch {}
+                    } catch { }
                   }, pendingMs)
                 }
 
@@ -2314,7 +2311,7 @@ export class Router<
                         // Update the match and prematurely resolve the loadMatches promise so that
                         // the pending component can start rendering
                         triggerOnReady()
-                      } catch {}
+                      } catch { }
                     }, pendingMs)
                   }
 
@@ -2623,7 +2620,7 @@ export class Router<
                     if (preload && route.options.preload === false) {
                       // Do nothing
                     } else if (loaderRunningAsync) {
-                      ;(async () => {
+                      ; (async () => {
                         try {
                           await runLoader()
                         } catch (err) {
@@ -2657,7 +2654,7 @@ export class Router<
             await Promise.all(matchPromises)
 
             resolveAll()
-          } catch (err) {
+          } catch (err: any) {
             console.warn(err.stack)
             rejectAll(err)
           }
@@ -2893,9 +2890,9 @@ export class Router<
       ...location,
       to: location.to
         ? this.resolvePathWithBase(
-            (location.from || '') as string,
-            location.to as string,
-          )
+          (location.from || '') as string,
+          location.to as string,
+        )
         : undefined,
       params: location.params || {},
       leaveParams: true,
@@ -2949,9 +2946,9 @@ export class Router<
             // send a small subset of the error to the client
             error: d.error
               ? {
-                  data: pickError(d.error),
-                  __isServerError: true,
-                }
+                data: pickError(d.error),
+                __isServerError: true,
+              }
               : undefined,
             // NOTE: We don't send the loader data here, because
             // there is a potential that it needs to be streamed.
@@ -3018,11 +3015,10 @@ export class Router<
   }
   injectScript = (script: string, opts?: { logScript?: boolean }) => {
     this.injectHtml(
-      `<script class='tsr-once'>${script}${
-        process.env.NODE_ENV === 'development' && (opts?.logScript ?? true)
-          ? `; console.info(\`Injected From Server:
+      `<script class='tsr-once'>${script}${process.env.NODE_ENV === 'development' && (opts?.logScript ?? true)
+        ? `; console.info(\`Injected From Server:
 ${script}\`)`
-          : ''
+        : ''
       }; if (typeof __TSR__ !== 'undefined') __TSR__.cleanScripts()</script>`,
     )
   }
@@ -3139,9 +3135,9 @@ export function lazyFn<
   }
 }
 
-export class SearchParamError extends Error {}
+export class SearchParamError extends Error { }
 
-export class PathParamError extends Error {}
+export class PathParamError extends Error { }
 
 export function getInitialRouterState(
   location: ParsedLocation,

--- a/packages/solid-router/src/router.ts
+++ b/packages/solid-router/src/router.ts
@@ -16,7 +16,6 @@ import {
   defaultTransformer,
   functionalUpdate,
   interpolatePath,
-  isMatch,
   joinPaths,
   last,
   matchPathname,
@@ -31,10 +30,6 @@ import {
 } from '@tanstack/router-core'
 import { isRedirect, isResolvedRedirect } from './redirects'
 import { isNotFound } from './not-found'
-import type {
-  TrailingSlashOption,
-  ViewTransitionOptions,
-} from '@tanstack/router-core'
 import type * as Solid from 'solid-js'
 import type {
   HistoryLocation,
@@ -42,7 +37,6 @@ import type {
   RouterHistory,
 } from '@tanstack/history'
 import type { NoInfer } from '@tanstack/solid-store'
-import type { Manifest } from '@tanstack/router-core'
 import type {
   AnyContext,
   AnyRoute,
@@ -65,10 +59,20 @@ import type {
   RoutesByPath,
 } from './routeInfo'
 import type {
+  AnySchema,
+  AnyValidator,
   ControlledPromise,
+  Manifest,
   NonNullableUpdater,
+  ParsedLocation,
   PickAsRequired,
+  ResolveRelativePath,
+  RouterTransformer,
+  SearchParser,
+  SearchSerializer,
+  TrailingSlashOption,
   Updater,
+  ViewTransitionOptions,
 } from '@tanstack/router-core'
 import type {
   AnyRouteMatch,
@@ -76,8 +80,6 @@ import type {
   MakeRouteMatchUnion,
   MatchRouteOptions,
 } from './Matches'
-import type { ParsedLocation } from '@tanstack/router-core'
-import type { SearchParser, SearchSerializer } from '@tanstack/router-core'
 import type {
   BuildLocationFn,
   CommitLocationOptions,
@@ -86,9 +88,6 @@ import type {
 import type { AnyRedirect, ResolvedRedirect } from './redirects'
 import type { NotFoundError } from './not-found'
 import type { NavigateOptions, ToOptions } from './link'
-import type { RouterTransformer } from '@tanstack/router-core'
-import type { AnySchema, AnyValidator } from '@tanstack/router-core'
-import type { ResolveRelativePath } from '@tanstack/router-core'
 
 declare global {
   interface Window {

--- a/packages/solid-router/src/scroll-restoration.tsx
+++ b/packages/solid-router/src/scroll-restoration.tsx
@@ -1,8 +1,7 @@
 import * as Solid from 'solid-js'
 import { functionalUpdate } from '@tanstack/router-core'
 import { useRouter } from './useRouter'
-import type { ParsedLocation } from '@tanstack/router-core'
-import type { NonNullableUpdater } from '@tanstack/router-core'
+import type { NonNullableUpdater, ParsedLocation } from '@tanstack/router-core'
 
 const windowKey = 'window'
 const delimiter = '___'

--- a/packages/solid-router/src/scroll-restoration.tsx
+++ b/packages/solid-router/src/scroll-restoration.tsx
@@ -50,7 +50,7 @@ export type ScrollRestorationOptions = {
  * The `location.href` is used as a fallback to support the use case where the location state is not available like the initial render.
  */
 const defaultGetKey = (location: ParsedLocation) => {
-  return location.state.key! || location.href
+  return location.state.key || location.href
 }
 
 export function useScrollRestoration(options?: ScrollRestorationOptions) {

--- a/packages/solid-router/src/useLoaderData.tsx
+++ b/packages/solid-router/src/useLoaderData.tsx
@@ -1,5 +1,5 @@
-import * as Solid from 'solid-js'
 import { useMatch } from './useMatch'
+import type * as Solid from 'solid-js'
 import type { AnyRouter, RegisteredRouter } from './router'
 import type { AllLoaderData, RouteById } from './routeInfo'
 import type { StrictOrFrom } from './utils'

--- a/packages/solid-router/src/useParams.tsx
+++ b/packages/solid-router/src/useParams.tsx
@@ -1,5 +1,5 @@
-import type * as Solid from 'solid-js'
 import { useMatch } from './useMatch'
+import type * as Solid from 'solid-js'
 import type { AllParams, RouteById } from './routeInfo'
 import type { AnyRouter, RegisteredRouter } from './router'
 import type { StrictOrFrom } from './utils'

--- a/packages/solid-router/src/useRouteContext.ts
+++ b/packages/solid-router/src/useRouteContext.ts
@@ -1,5 +1,5 @@
-import * as Solid from 'solid-js'
 import { useMatch } from './useMatch'
+import type * as Solid from 'solid-js'
 import type { AllContext, RouteById } from './routeInfo'
 import type { AnyRouter, RegisteredRouter } from './router'
 import type { StrictOrFrom } from './utils'

--- a/packages/solid-router/src/useSearch.tsx
+++ b/packages/solid-router/src/useSearch.tsx
@@ -61,5 +61,7 @@ export function useSearch<
     select: (match: any) => {
       return opts.select ? opts.select(match.search) : match.search
     },
-  }) as Solid.Accessor<UseSearchResult<TRouter, TFrom, TStrict, TSelected>>
+  } as any) as Solid.Accessor<
+    UseSearchResult<TRouter, TFrom, TStrict, TSelected>
+  >
 }

--- a/packages/solid-router/src/useSearch.tsx
+++ b/packages/solid-router/src/useSearch.tsx
@@ -1,5 +1,5 @@
-import * as Solid from 'solid-js'
 import { useMatch } from './useMatch'
+import type * as Solid from 'solid-js'
 import type { FullSearchSchema, RouteById } from './routeInfo'
 import type { AnyRouter, RegisteredRouter } from './router'
 import type { StrictOrFrom } from './utils'

--- a/packages/solid-router/tests/createLazyRoute.test.tsx
+++ b/packages/solid-router/tests/createLazyRoute.test.tsx
@@ -1,10 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-} from '@solidjs/testing-library'
+import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
 import {
   Link,
   RouterProvider,

--- a/packages/solid-router/tests/createLazyRoute.test.tsx
+++ b/packages/solid-router/tests/createLazyRoute.test.tsx
@@ -1,7 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   cleanup,
-  configure,
   fireEvent,
   render,
   screen,
@@ -54,8 +53,6 @@ function createTestRouter(initialHistory?: RouterHistory) {
 }
 
 describe('preload: matched routes', { timeout: 20000 }, () => {
-  configure({ reactStrictMode: true })
-
   it('should wait for lazy options to be streamed in before ', async () => {
     const { router } = createTestRouter(
       createMemoryHistory({ initialEntries: ['/'] }),

--- a/packages/solid-router/tests/redirect.test.tsx
+++ b/packages/solid-router/tests/redirect.test.tsx
@@ -1,9 +1,4 @@
-import {
-  cleanup,
-  fireEvent,
-  render,
-  screen,
-} from '@solidjs/testing-library'
+import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
 
 import { afterEach, describe, expect, test, vi } from 'vitest'
 

--- a/packages/solid-router/tests/redirect.test.tsx
+++ b/packages/solid-router/tests/redirect.test.tsx
@@ -1,6 +1,5 @@
 import {
   cleanup,
-  configure,
   fireEvent,
   render,
   screen,
@@ -32,7 +31,6 @@ const WAIT_TIME = 100
 
 describe('redirect', () => {
   describe('SPA', () => {
-    configure({ reactStrictMode: true })
     test('when `redirect` is thrown in `beforeLoad`', async () => {
       const nestedLoaderMock = vi.fn()
       const nestedFooLoaderMock = vi.fn()

--- a/packages/solid-router/tests/router.test.tsx
+++ b/packages/solid-router/tests/router.test.tsx
@@ -7,6 +7,7 @@ import {
   waitFor,
 } from '@solidjs/testing-library'
 import { z } from 'zod'
+import { onMount } from 'solid-js'
 import {
   Link,
   Outlet,
@@ -17,7 +18,6 @@ import {
   createRouter,
 } from '../src'
 import type { AnyRoute, AnyRouter, RouterOptions } from '../src'
-import { onMount } from 'solid-js'
 
 afterEach(() => {
   vi.resetAllMocks()

--- a/packages/solid-router/tests/searchMiddleware.test.tsx
+++ b/packages/solid-router/tests/searchMiddleware.test.tsx
@@ -53,11 +53,11 @@ function setupTest(opts: {
   })
 
   const PostsComponent = () => {
-    const { value } = postsRoute.useSearch()
+    const search = postsRoute.useSearch()
     return (
       <>
         <h1 data-testid="posts-heading">Posts</h1>
-        <div data-testid="search">{value ?? '$undefined'}</div>
+        <div data-testid="search">{search().value ?? '$undefined'}</div>
       </>
     )
   }

--- a/packages/solid-router/tests/useMatch.test.tsx
+++ b/packages/solid-router/tests/useMatch.test.tsx
@@ -59,8 +59,8 @@ describe('useMatch', () => {
       async (shouldThrow) => {
         function RootComponent() {
           const match = useMatch({ from: '/posts', shouldThrow })
-          expect(match).toBeDefined()
-          expect(match!.routeId).toBe('/posts')
+          expect(match()).toBeDefined()
+          expect(match()!.routeId).toBe('/posts')
           return <Outlet />
         }
 

--- a/packages/solid-router/tests/useNavigate.test.tsx
+++ b/packages/solid-router/tests/useNavigate.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom/vitest'
 import { afterEach, expect, test } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library'
+import * as Solid from 'solid-js'
 
 import { z } from 'zod'
 import {
@@ -139,7 +140,7 @@ test('when navigating from /posts to ./$postId', async () => {
     const navigate = useNavigate()
     return (
       <>
-        <span>Params: {params.postId}</span>
+        <span>Params: {params().postId}</span>
         <button onClick={() => navigate({ to: '/' })}>Index</button>
       </>
     )
@@ -249,7 +250,7 @@ test('when navigating from /posts to ../posts/$postId', async () => {
     const params = useParams({ strict: false })
     return (
       <>
-        <span>Params: {params.postId}</span>
+        <span>Params: {params().postId}</span>
         <button onClick={() => navigate({ to: '/' })}>Index</button>
       </>
     )
@@ -346,7 +347,7 @@ test('when navigating from /posts/$postId to /posts/$postId/info and the current
     const params = useParams({ strict: false })
     return (
       <>
-        <span>Params: {params.postId}</span>
+        <span>Params: {params().postId}</span>
         <Outlet />
       </>
     )
@@ -491,7 +492,7 @@ test('when navigating from /posts/$postId to ./info and the current route is /po
     const params = useParams({ strict: false })
     return (
       <>
-        <span>Params: {params.postId}</span>
+        <span>Params: {params().postId}</span>
         <Outlet />
       </>
     )
@@ -634,7 +635,7 @@ test('when navigating from /posts/$postId to ../$postId and the current route is
     const params = useParams({ strict: false })
     return (
       <>
-        <span>Params: {params.postId}</span>
+        <span>Params: {params().postId}</span>
         <Outlet />
       </>
     )
@@ -775,7 +776,7 @@ test('when navigating from /posts/$postId with an index to ../$postId and the cu
     const params = useParams({ strict: false })
     return (
       <>
-        <span>Params: {params.postId}</span>
+        <span>Params: {params().postId}</span>
         <Outlet />
       </>
     )
@@ -926,7 +927,7 @@ test('when navigating from /invoices to ./invoiceId and the current route is /po
     const params = useParams({ strict: false })
     return (
       <>
-        <span>Params: {params.postId}</span>
+        <span>Params: {params().postId}</span>
         <Outlet />
       </>
     )
@@ -940,7 +941,7 @@ test('when navigating from /invoices to ./invoiceId and the current route is /po
 
   const DetailsComponent = () => {
     const navigate = useNavigate()
-    const [error, setError] = React.useState<unknown>()
+    const [_error, setError] = Solid.createSignal<unknown>()
     return (
       <>
         <h1>Details!</h1>
@@ -999,7 +1000,7 @@ test('when navigating from /invoices to ./invoiceId and the current route is /po
     const params = useParams({ strict: false })
     return (
       <>
-        <span>invoiceId: {params.invoiceId}</span>
+        <span>invoiceId: {params().invoiceId}</span>
       </>
     )
   }
@@ -1083,7 +1084,7 @@ test('when navigating to /posts/$postId/info which is masked as /posts/$postId',
     const params = useParams({ strict: false })
     return (
       <>
-        <span>Params: {params.postId}</span>
+        <span>Params: {params().postId}</span>
         <Outlet />
       </>
     )
@@ -1184,7 +1185,7 @@ test('when navigating to /posts/$postId/info which is imperatively masked as /po
     const params = useParams({ strict: false })
     return (
       <>
-        <span>Params: {params.postId}</span>
+        <span>Params: {params().postId}</span>
         <Outlet />
       </>
     )
@@ -1241,8 +1242,8 @@ test('when setting search params with 2 parallel navigate calls', async () => {
     return (
       <>
         <h1>Index</h1>
-        <div data-testid="param1">{search.param1}</div>
-        <div data-testid="param2">{search.param2}</div>
+        <div data-testid="param1">{search().param1}</div>
+        <div data-testid="param2">{search().param2}</div>
         <button
           onClick={() => {
             navigate({

--- a/packages/solid-router/tsconfig.build.json
+++ b/packages/solid-router/tsconfig.build.json
@@ -8,7 +8,8 @@
     "outDir": "dist/source",
     "noEmit": false,
     "declaration": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "target": "ES2015"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
PR contains some fixes for tests. **Most importantly, build works, so examples can be created** - if you delete `__TSR_index` from `history` build package

Unfortunately `render` from `@solidjs/testing-library` does not update router state, nor renders the route components. So many tests still fail.

Also fixes:
- all eslint
- all type tests (except test:types:ts52)
- some unit tests

Some fixes are dodgy, especially the type tests. But at least we can validate that we are on the right track with examples
